### PR TITLE
migrate auth.status command to use new api.host endpoints in sdk-go

### DIFF
--- a/command/auth/status.go
+++ b/command/auth/status.go
@@ -27,11 +27,11 @@ var statusCmd = &cobra.Command{
 
 		client := _ctx.ServiceClientConfig.API.GetRestClient()
 
-		loginUri := host.Endpoint.Rest.Auth.Login
+		checkUri := host.Endpoint.Rest.Auth.Check
 
 		var jsonData = []byte(fmt.Sprintf(`{"username": "%s"}`, _config.Auth.Username))
 
-		request, err := client.NewRequest("POST", loginUri, api.RequestHeaders{
+		request, err := client.NewRequest("POST", checkUri, api.RequestHeaders{
 			api.WithContentType(api.ContentTypeJson),
 		}, jsonData)
 		cobra.CheckErr(err)
@@ -44,7 +44,7 @@ var statusCmd = &cobra.Command{
 		} else if response.StatusCode == 401 {
 			cmd.Println("Invalid username or token. Please login again.")
 		} else {
-			cobra.CheckErr(errors.New("could not check login status with server"))
+			cobra.CheckErr(errors.New(fmt.Sprintf("could not check login status with server error status: %s", response.Status)))
 		}
 
 	},

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.18.36
 	github.com/aws/aws-sdk-go-v2/service/iam v1.21.0
 	github.com/briandowns/spinner v1.23.0
-	github.com/deploifai/sdk-go v0.0.6
+	github.com/deploifai/sdk-go v0.0.7
 	github.com/schollz/progressbar/v3 v3.13.1
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/viper v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -137,6 +137,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/deploifai/sdk-go v0.0.6 h1:+pnbiXBHie+tW8UWvcbGo04hb95ToUZr3mcRyA8iOFg=
 github.com/deploifai/sdk-go v0.0.6/go.mod h1:Q0hRKGx4JtXfWnu1ZjCvwx8q+DSw9/xpoouZa2DAQ+M=
+github.com/deploifai/sdk-go v0.0.7 h1:TK8amnil4fPVlnb00IGqWfNXgsJlGKqPbckUnIKX8bc=
+github.com/deploifai/sdk-go v0.0.7/go.mod h1:Q0hRKGx4JtXfWnu1ZjCvwx8q+DSw9/xpoouZa2DAQ+M=
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=


### PR DESCRIPTION
- use Auth.Check uri for auth.status command
- upgrade github.com/deploifai/sdk-go to v0.0.7 in go.mod
